### PR TITLE
Fixed env naming mismatch

### DIFF
--- a/config/at.config.js
+++ b/config/at.config.js
@@ -1,6 +1,6 @@
 // africa's talking api
 const atCredentials = {
-  apiKey: process.env.TEST_AT_API_KEY,
+  apiKey: process.env.AT_API_KEY,
   username: process.env.AT_API_USERNAME
 }
 


### PR DESCRIPTION
Fixing callback error--> root cause naming mismatch. 
```
2022-03-07 19:31:26 default[version1]  /layers/google.nodejs.yarn/yarn_modules/node_modules/africastalking/lib/index.js:44
2022-03-07 19:31:26 default[version1]          throw error;
2022-03-07 19:31:26 default[version1]          ^
2022-03-07 19:31:26 default[version1]  { apiKey: [ "Api key can't be blank" ] }
```